### PR TITLE
GraalPy Implementation Example

### DIFF
--- a/wrims-core/build.gradle
+++ b/wrims-core/build.gradle
@@ -3,6 +3,7 @@ plugins{
     id 'antlr'
     id 'library.deps-conventions'
     id 'library.java-conventions'
+    id("org.graalvm.python") version "24.2.1"
     id 'library.publishing-conventions'
 }
 
@@ -62,6 +63,10 @@ dependencies {
     implementation libs.lpsolve55j
     implementation libs.xaoptimizer
     implementation libs.calsurrogate
+
+    // GraalPy
+    implementation("org.graalvm.polyglot:polyglot:24.2.1")
+    implementation("org.graalvm.polyglot:python:24.2.1")
 }
 
 // This moves .tokens files into the same generated-src files with the .java files

--- a/wrims-core/src/test/java/graalpy/HelloWorld.java
+++ b/wrims-core/src/test/java/graalpy/HelloWorld.java
@@ -1,0 +1,7 @@
+package graalpy;
+
+interface HelloWorld {
+    void main();
+
+    String getText();
+}

--- a/wrims-core/src/test/java/graalpy/HelloWorld.java
+++ b/wrims-core/src/test/java/graalpy/HelloWorld.java
@@ -1,7 +1,7 @@
 package graalpy;
 
 interface HelloWorld {
-    void main();
+    void printTest();
 
     String getText();
 }

--- a/wrims-core/src/test/java/graalpy/JavaTest.java
+++ b/wrims-core/src/test/java/graalpy/JavaTest.java
@@ -1,11 +1,11 @@
 package graalpy;
 
 public interface JavaTest {
-    void main();
+    void instanceTest();
 
     String getText();
 
-    boolean isTrue();
+    boolean isAnInteger(Object value);
 
-    int getNumber(int x, int y);
+    int getAbsoluteDifference(int x, int y);
 }

--- a/wrims-core/src/test/java/graalpy/JavaTest.java
+++ b/wrims-core/src/test/java/graalpy/JavaTest.java
@@ -1,0 +1,11 @@
+package graalpy;
+
+public interface JavaTest {
+    void main();
+
+    String getText();
+
+    boolean isTrue();
+
+    int getNumber(int x, int y);
+}

--- a/wrims-core/src/test/java/graalpy/MyCustomClass.java
+++ b/wrims-core/src/test/java/graalpy/MyCustomClass.java
@@ -2,15 +2,19 @@ package graalpy;
 
 public final class MyCustomClass {
 
-    public void main() {
+    public void printTest() {
         System.out.println("Hello from MyCustomClass!");
     }
 
-    public static boolean isTrue() {
-        return true;
+    public static boolean isAnInteger(Object value) {
+        return (value instanceof Integer);
     }
 
-    public int getNumber(int x, int y) {
+    public int getAbsoluteDifference(int x, int y) {
         return Math.abs(x - y);
+    }
+
+    public String getText() {
+        return "JavaTest instance with custom class";
     }
 }

--- a/wrims-core/src/test/java/graalpy/MyCustomClass.java
+++ b/wrims-core/src/test/java/graalpy/MyCustomClass.java
@@ -1,0 +1,16 @@
+package graalpy;
+
+public final class MyCustomClass {
+
+    public void main() {
+        System.out.println("Hello from MyCustomClass!");
+    }
+
+    public static boolean isTrue() {
+        return true;
+    }
+
+    public int getNumber(int x, int y) {
+        return Math.abs(x - y);
+    }
+}

--- a/wrims-core/src/test/java/graalpy/PythonTest.java
+++ b/wrims-core/src/test/java/graalpy/PythonTest.java
@@ -1,6 +1,7 @@
 package graalpy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
@@ -20,7 +21,7 @@ final class PythonTest {
             context.eval("python", "sys.path.append(sys_path)");
 
             HelloWorld world = context.eval("python", "from HelloWorld import HelloWorld; HelloWorld()").as(HelloWorld.class);
-            world.main();
+            world.printTest();
 
             String result = world.getText();
             assertEquals("Hello, World!", result);
@@ -37,12 +38,24 @@ final class PythonTest {
             context.eval("python", "sys.path.append(sys_path)");
 
             JavaTest test = context.eval("python", "from JavaTest import JavaTest; JavaTest()").as(JavaTest.class);
-            test.main();
+            test.instanceTest();
 
-            boolean isTrue = test.isTrue();
+            boolean isTrue = test.isAnInteger(3);
             assertTrue(isTrue);
 
-            int number = test.getNumber(5, 10);
+            boolean isFalse = test.isAnInteger("This is a string");
+            assertFalse(isFalse);
+
+            boolean isFalse2 = test.isAnInteger(3.14);
+            assertFalse(isFalse2);
+
+            boolean isFalse3 = test.isAnInteger(null);
+            assertFalse(isFalse3);
+
+            boolean isFalse4 = test.isAnInteger("56");
+            assertFalse(isFalse4);
+
+            int number = test.getAbsoluteDifference(5, 10);
             assertEquals(5, number);
 
             String result = test.getText();

--- a/wrims-core/src/test/java/graalpy/PythonTest.java
+++ b/wrims-core/src/test/java/graalpy/PythonTest.java
@@ -1,0 +1,32 @@
+package graalpy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Path;
+import org.graalvm.polyglot.Context;
+import org.graalvm.python.embedding.GraalPyResources;
+import org.junit.jupiter.api.Test;
+
+final class PythonTest {
+
+    @Test
+    void testRunHelloWorld() {
+        String path = "src/test/resources/python";
+        try (var context = createPythonContext(path)) {
+            // Configure the Python context to include the path to the Python resources, otherwise a ModuleNotFoundError will occur
+            context.getBindings("python").putMember("sys_path", path);
+            context.eval("python", "import sys");
+            context.eval("python", "sys.path.append(sys_path)");
+
+            HelloWorld world = context.eval("python", "import HelloWorld; HelloWorld").as(HelloWorld.class);
+            world.main();
+
+            String result = world.getText();
+            assertEquals("Hello, World!", result);
+        }
+    }
+
+    static Context createPythonContext(String pythonResourcesDirectory) {
+        return GraalPyResources.contextBuilder(Path.of(pythonResourcesDirectory)).build();
+    }
+}

--- a/wrims-core/src/test/java/graalpy/PythonTest.java
+++ b/wrims-core/src/test/java/graalpy/PythonTest.java
@@ -1,6 +1,7 @@
 package graalpy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import org.graalvm.polyglot.Context;
@@ -18,11 +19,34 @@ final class PythonTest {
             context.eval("python", "import sys");
             context.eval("python", "sys.path.append(sys_path)");
 
-            HelloWorld world = context.eval("python", "import HelloWorld; HelloWorld").as(HelloWorld.class);
+            HelloWorld world = context.eval("python", "from HelloWorld import HelloWorld; HelloWorld()").as(HelloWorld.class);
             world.main();
 
             String result = world.getText();
-            assertEquals("Hello, World 2!", result);
+            assertEquals("Hello, World!", result);
+        }
+    }
+
+    @Test
+    void testRunJavaTest() {
+        String path = "src/test/resources/python";
+        try (var context = createPythonContext(path)) {
+            // Configure the Python context to include the path to the Python resources, otherwise a ModuleNotFoundError will occur
+            context.getBindings("python").putMember("sys_path", path);
+            context.eval("python", "import sys");
+            context.eval("python", "sys.path.append(sys_path)");
+
+            JavaTest test = context.eval("python", "from JavaTest import JavaTest; JavaTest()").as(JavaTest.class);
+            test.main();
+
+            boolean isTrue = test.isTrue();
+            assertTrue(isTrue);
+
+            int number = test.getNumber(5, 10);
+            assertEquals(5, number);
+
+            String result = test.getText();
+            assertEquals("JavaTest instance with custom class", result);
         }
     }
 

--- a/wrims-core/src/test/java/graalpy/PythonTest.java
+++ b/wrims-core/src/test/java/graalpy/PythonTest.java
@@ -22,11 +22,11 @@ final class PythonTest {
             world.main();
 
             String result = world.getText();
-            assertEquals("Hello, World!", result);
+            assertEquals("Hello, World 2!", result);
         }
     }
 
     static Context createPythonContext(String pythonResourcesDirectory) {
-        return GraalPyResources.contextBuilder(Path.of(pythonResourcesDirectory)).build();
+        return GraalPyResources.contextBuilder(Path.of(pythonResourcesDirectory)).allowAllAccess(true).build();
     }
 }

--- a/wrims-core/src/test/resources/python/HelloWorld.py
+++ b/wrims-core/src/test/resources/python/HelloWorld.py
@@ -1,11 +1,15 @@
+import java
+
 def __init__(self):
     pass
 
 def main():
     print("Hello, World!")
+    System = java.type("java.lang.System")
+    System.out.println("Hello from Java System.out.println!")
 
 def getText():
-    return "Hello, World!"
+    return "Hello, World 2!"
 
 if __name__ == "__main__":
     main()

--- a/wrims-core/src/test/resources/python/HelloWorld.py
+++ b/wrims-core/src/test/resources/python/HelloWorld.py
@@ -9,7 +9,7 @@ class HelloWorld:
     def __str__(self):
         return "Hello, World!"
 
-    def main(self):
+    def printTest(self):
         print(str(self))
         System.out.println("Hello from Java System.out.println!")
 
@@ -18,4 +18,4 @@ class HelloWorld:
 
 
 if __name__ == "__main__":
-    HelloWorld().main()
+    HelloWorld().printTest()

--- a/wrims-core/src/test/resources/python/HelloWorld.py
+++ b/wrims-core/src/test/resources/python/HelloWorld.py
@@ -1,0 +1,11 @@
+def __init__(self):
+    pass
+
+def main():
+    print("Hello, World!")
+
+def getText():
+    return "Hello, World!"
+
+if __name__ == "__main__":
+    main()

--- a/wrims-core/src/test/resources/python/HelloWorld.py
+++ b/wrims-core/src/test/resources/python/HelloWorld.py
@@ -1,15 +1,21 @@
 import java
 
-def __init__(self):
-    pass
+System = java.type("java.lang.System")
 
-def main():
-    print("Hello, World!")
-    System = java.type("java.lang.System")
-    System.out.println("Hello from Java System.out.println!")
+class HelloWorld:
+    def __init__(self):
+        pass
 
-def getText():
-    return "Hello, World 2!"
+    def __str__(self):
+        return "Hello, World!"
+
+    def main(self):
+        print(str(self))
+        System.out.println("Hello from Java System.out.println!")
+
+    def getText(self):
+        return str(self)
+
 
 if __name__ == "__main__":
-    main()
+    HelloWorld().main()

--- a/wrims-core/src/test/resources/python/JavaTest.py
+++ b/wrims-core/src/test/resources/python/JavaTest.py
@@ -1,0 +1,29 @@
+import java
+
+System = java.type("java.lang.System")
+MyCustomClass = java.type("graalpy.MyCustomClass")  # Adjust
+
+class JavaTest:
+    def __init__(self):
+        self.custom_class = MyCustomClass()
+
+    def __str__(self):
+        return "JavaTest instance with custom class"
+
+    def main(self):
+        print(str(self))
+        System.out.println("Hello from Java System.out.println!")
+        self.custom_class.main()
+        if (MyCustomClass.isTrue()):
+            System.out.println("Custom class is true")
+
+        System.out.println("Number from custom class: " + str(self.custom_class.getNumber(2, 3)))
+
+    def getText(self):
+        return str(self)
+
+    def isTrue(self):
+        return MyCustomClass.isTrue()
+
+    def getNumber(self, a, b):
+        return self.custom_class.getNumber(a, b)

--- a/wrims-core/src/test/resources/python/JavaTest.py
+++ b/wrims-core/src/test/resources/python/JavaTest.py
@@ -4,26 +4,27 @@ System = java.type("java.lang.System")
 MyCustomClass = java.type("graalpy.MyCustomClass")  # Adjust
 
 class JavaTest:
-    def __init__(self):
-        self.custom_class = MyCustomClass()
-
     def __str__(self):
         return "JavaTest instance with custom class"
 
-    def main(self):
+    def instanceTest(self):
+        custom_instance = MyCustomClass()
         print(str(self))
         System.out.println("Hello from Java System.out.println!")
-        self.custom_class.main()
-        if (MyCustomClass.isTrue()):
-            System.out.println("Custom class is true")
+        custom_instance.printTest()
+        if (MyCustomClass.isAnInteger(3)):
+            System.out.println("Provided value is an integer")
 
-        System.out.println("Number from custom class: " + str(self.custom_class.getNumber(2, 3)))
+        if not MyCustomClass.isAnInteger("Hello"):
+            System.out.println("Provided value is not an integer")
+
+        System.out.println("Number from custom class: " + str(custom_instance.getAbsoluteDifference(2, 3)))
 
     def getText(self):
-        return str(self)
+        return MyCustomClass().getText()
 
-    def isTrue(self):
-        return MyCustomClass.isTrue()
+    def isAnInteger(self, value):
+        return MyCustomClass.isAnInteger(value)
 
-    def getNumber(self, a, b):
-        return self.custom_class.getNumber(a, b)
+    def getAbsoluteDifference(self, a, b):
+        return MyCustomClass().getAbsoluteDifference(a, b)


### PR DESCRIPTION
# Description

Added unit test for GraalPy support using GraalVM. Includes simple HelloWorld python file and Java interface.

Resolves #3 
# Motivation and Context

This demonstrates that the Java 21 build will run with GraalVM. It also shows possible usages of GraalPy for Python integration with the project.
# How Has This Been Tested?

This was tested with both GraalVM 21 and Temurin 21 JDKs.

Initial test was run using IntelliJ on Zack's development computer
# Screenshots (if appropriate):
# Types of changes

Added dependencies for Graal and test code to show integration with Python.