### PR TITLE
Issue #70 - Adding and adjusting gradle build tasks support headless computes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,49 @@ Prior to the present revison of the WRIMS build system, the equivalent of WRIMS-
 1. **Clone the repository:**
    ```sh
    git clone https://github.com/CentralValleyModeling/wrims-engine.git
+   
+# RUNNING HEADLESS WRIMS ENGINE COMPUTE
+The WRIMS engine can be run headless (without the GUI) using the `wrims-core` jar along with all dependency jars and libs. 
+This is useful for running batch processes or automated tests.
+
+Here are the required steps to run a headless compute with the WRIMS engine jar directly:
+
+1. Build the wrims-core module. This will create a jar file in the `wrims-core/build/libs` directory and the copy the dependent jars into `wrims-core/build/tmp/libs`.
+   ```sh
+   ./gradlew :wrims-core:build
+   ```
+2. Run the "getNatives" task in the wrims-core module. This will download all the required dll files into the `wrims-core/build/tmp/x64` directory. 
+   ```sh
+    ./gradlew :wrims-core:getNatives
+   ```
+3. Create a batch file in the root directory of the wrims-engine folder named run_project.bat with the following template. Update the project directory and config file as needed.
+   ```bat
+   @echo off
+   REM PROJECT SETTINGS: PROJECT_DIR, and CONFIG_FILE variables as needed.
+   set PROJECT_DIR=wrims-comparison-test\build\testProjects\dcr2023
+   set CONFIG_FILE=test.config
+   
+   REM Set the JAVA_HOME environment variable to the path of your java 21 JDK
+   set JAVA_HOME="C:\Users\josh\.jdks\corretto-21.0.3"
+   
+   set temp_wrims2=".\foo"
+   
+   REM Add the required DLLs to the PATH. Do not change if this if run from the wrims-engine root directory.
+   set PATH=%PATH%;wrims-core\build\tmp\x64
+   
+   REM Add the external libraries to the PATH. Do not change.
+   set PATH=%PATH%;%PROJECT_DIR%\Run\External
+   
+   REM Set the main class to run. This is the entry point for the WRIMS application. Do not change when running from wrims-engine root.
+   set MAIN_CLASS=wrimsv2.components.ControllerBatch
+   set WRIMS_CORE_JAR="wrims-core\build\libs\*"
+   set WRIMS_CORE_DEPENDENCIES="wrims-core\build\tmp\libs\*"
+   
+   %JAVA_HOME%\bin\java -Xmx4096m -Xss1024K -cp "%WRIMS_CORE_JAR%;%WRIMS_CORE_DEPENDENCIES%" %MAIN_CLASS% -config=%PROJECT_DIR%\%CONFIG_FILE%
+   pause
+   ```   
+
+4. Run the batch file from a terminal or double-click it to execute the bat file.
+   ```sh
+   run_project.bat
+   ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Prior to the present revison of the WRIMS build system, the equivalent of WRIMS-
 1. **Clone the repository:**
    ```sh
    git clone https://github.com/CentralValleyModeling/wrims-engine.git
+   ```
    
 # RUNNING HEADLESS WRIMS ENGINE COMPUTE
 The WRIMS engine can be run headless (without the GUI) using the `wrims-core` jar along with all dependency jars and libs. 
@@ -40,15 +41,15 @@ Here are the required steps to run a headless compute with the WRIMS engine jar 
    ```sh
     ./gradlew :wrims-core:getNatives
    ```
-3. Create a batch file in the root directory of the wrims-engine folder named run_project.bat with the following template. Update the project directory and config file as needed.
+3. Clone the run_wrims_study_example.bat file in the root directory of the wrims-engine folder and update the project directory and config file paths.
    ```bat
    @echo off
    REM PROJECT SETTINGS: PROJECT_DIR, and CONFIG_FILE variables as needed.
-   set PROJECT_DIR=wrims-comparison-test\build\testProjects\dcr2023
-   set CONFIG_FILE=test.config
+   set PROJECT_DIR=J:\wrims\projects\dcr2023
+   set CONFIG_FILE=study.config
    
    REM Set the JAVA_HOME environment variable to the path of your java 21 JDK
-   set JAVA_HOME="C:\Users\josh\.jdks\corretto-21.0.3"
+   set JAVA_HOME="J:\java\jdk\jdk_21.0.8_temurin"
    
    set temp_wrims2=".\foo"
    

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,11 @@ def versionLabel(gitInfo) {
     return gitInfo.branchName == null ? tag : tag + ".9999"
 }
 
+tasks.register('copyDependencies', Copy) {
+    into 'build/tmp/libs'
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
 allprojects {
     group = 'gov.ca.dwr'
     version = versionLabel(versionDetails())

--- a/run_wrims_study_example.bat
+++ b/run_wrims_study_example.bat
@@ -1,0 +1,23 @@
+@echo off
+REM PROJECT SETTINGS: PROJECT_DIR, and CONFIG_FILE variables as needed.
+set PROJECT_DIR=J:\wrims\projects\dcr2023
+set CONFIG_FILE=study.config
+
+REM Set the JAVA_HOME environment variable to the path of your java 21 JDK
+set JAVA_HOME="J:\java\jdk\jdk_21.0.8_temurin"
+
+set temp_wrims2=".\foo"
+
+REM Add the required DLLs to the PATH. Do not change if this if run from the wrims-engine root directory.
+set PATH=%PATH%;wrims-core\build\tmp\x64
+
+REM Add the external libraries to the PATH. Do not change.
+set PATH=%PATH%;%PROJECT_DIR%\Run\External
+
+REM Set the main class to run. This is the entry point for the WRIMS application. Do not change when running from wrims-engine root.
+set MAIN_CLASS=wrimsv2.components.ControllerBatch
+set WRIMS_CORE_JAR="wrims-core\build\libs\*"
+set WRIMS_CORE_DEPENDENCIES="wrims-core\build\tmp\libs\*"
+
+%JAVA_HOME%\bin\java -Xmx4096m -Xss1024K -cp "%WRIMS_CORE_JAR%;%WRIMS_CORE_DEPENDENCIES%" %MAIN_CLASS% -config=%PROJECT_DIR%\%CONFIG_FILE%
+pause

--- a/wrims-comparison-test/build.gradle
+++ b/wrims-comparison-test/build.gradle
@@ -36,6 +36,20 @@ tasks.register("testExecute", JavaExec) {
     jvmArgs "-Xmx4096m", "-Xss1024K", "-XX:+CreateMinidumpOnCrash"
 }
 
+tasks.register("testExecuteDanube", JavaExec) {
+    def compareDirName = "$buildDir/testProjects/danube"
+    dependsOn(tasks.named("getNatives"))
+    workingDir "${buildDir}/testProjects/"
+    classpath = files("${compareDirName}/Run/external")
+    classpath += sourceSets.main.runtimeClasspath
+    mainClass = "wrimsv2.components.ControllerBatch"
+    args "-config=$buildDir/${project.findProperty('configFilePath') ?: "/testProjects/danube/test.config"}"
+    environment 'PATH', "${compareDirName}/Run/external;$buildDir/lib;${System.getenv('PATH')}"
+    systemProperty "java.library.path", "${compareDirName}/Run/external;$buildDir/lib"
+
+    jvmArgs "-Xmx4096m", "-Xss1024K", "-XX:+CreateMinidumpOnCrash"
+}
+
 tasks.register("testReport", JavaExec) {
     dependsOn(tasks.named("testExecute"))
     workingDir "${buildDir}/testProjects/"

--- a/wrims-comparison-test/build.gradle
+++ b/wrims-comparison-test/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 }
 
 tasks.register("testExecute", JavaExec) {
+    group = "compute-tests"
     def compareDirName = "$buildDir/testProjects/CalLite4.1_TF"
     dependsOn(tasks.named("getNatives"))
     dependsOn(tasks.named("getTestProjects"))
@@ -36,14 +37,17 @@ tasks.register("testExecute", JavaExec) {
     jvmArgs "-Xmx4096m", "-Xss1024K", "-XX:+CreateMinidumpOnCrash"
 }
 
-tasks.register("testExecuteDanube", JavaExec) {
-    def compareDirName = "$buildDir/testProjects/danube"
+tasks.register("executeDcr2023", JavaExec) {
+    group = "compute-tests"
+    def configFile = "test.config"
+    def projectFolder = "/testProjects/dcr2023"
+    def compareDirName = "$buildDir${projectFolder}"
     dependsOn(tasks.named("getNatives"))
     workingDir "${buildDir}/testProjects/"
     classpath = files("${compareDirName}/Run/external")
     classpath += sourceSets.main.runtimeClasspath
     mainClass = "wrimsv2.components.ControllerBatch"
-    args "-config=$buildDir/${project.findProperty('configFilePath') ?: "/testProjects/danube/test.config"}"
+    args "-config=$buildDir/${project.findProperty('configFilePath') ?: "${projectFolder}/${configFile}"}"
     environment 'PATH', "${compareDirName}/Run/external;$buildDir/lib;${System.getenv('PATH')}"
     systemProperty "java.library.path", "${compareDirName}/Run/external;$buildDir/lib"
 

--- a/wrims-core/build.gradle
+++ b/wrims-core/build.gradle
@@ -17,7 +17,14 @@ sourceSets {
     }
 }
 
+configurations{
+    windows_x64
+}
 
+dependencies {
+    windows_x64(libs.javaHeclib){artifact {type = 'zip'}}
+    windows_x64 libs.run.libs
+}
 
 dependencies {
     api(platform(project(":wrims-engine-bom")))
@@ -103,6 +110,17 @@ publishing {
     }
 }
 
+tasks.register('getNatives', Sync) { syncTask ->
+    syncTask.from configurations.windows_x64.collect { zipTree(it) }
+    syncTask.into file("${buildDir}/tmp/x64")
+}
+
 tasks.named('sourcesJar') {
     dependsOn tasks.named('generateGrammarSource')
 }
+
+tasks.named('build') {
+    dependsOn tasks.named('copyDependencies')
+}
+
+


### PR DESCRIPTION
# Description
@dwr-zroy reported missing libs issues when attempting run a danube compute using the latest wrims-engine. 

```
Exception in thread "main" java.lang.UnsatisfiedLinkError: no javaHeclib in java.library.path:...
```

This error indicates the javaheclib.dll could not be found in the system path, either added to the PATH variable through the BAT script or declared through a -D flag in the java arguments. 

The provided batch file script was tested with the associated project data ([9.3.1_danube_adj.zip](https://data.cnra.ca.gov/dataset/1fd287b9-fb19-40bc-9b3f-ab0e3359b988/resource/1ce159b9-51de-4073-8da9-9ec11f8874b7/download/9.3.1_danube_adj.zip))

Batch File
```
@echo off
set JAVA_HOME="C:\Users\zroy\AppData\Local\Programs\Eclipse Adoptium\jdk-21.0.5.11-hotspot"
set temp_wrims2=".\foo"

%JAVA_HOME%\bin\java -Xmx4096m -Xss1024K -cp "wrims-core\build\libs\*;wrims-core\build\tmp\libs\*" wrimsv2.components.ControllerBatch -launch=C:\Users\zroy\Documents\_Modeling\_2023DCR\_studies\9.3.1_danube_adj\CS3_Adjusted_Dev.launch
pause
```

The folder containing the javaHeclib and other required .dlls must be included in the java Path either by setting them in the Batch File or by passing them through a java -D argument. Additionally, all dependency jars needed to be included in the java classpath. 

This PR adds the "getNatives" task as a helper gradle function that a developer can run to load the dll's into the \wrims-core\build\tmp\x64 folder. 

A "copyDependencies" task has also been added to automatically output a copy of all dependency jars into \wrims-core\build\tmp\libs when the build is run. 

# Motivation and Context

# How Has This Been Tested?
These updates were tested by download the project data, running the updated build of wrims-engine, then running the "getNatives" task to populate the dll libs locally. Then the following bat script was run from the root folder the of wrims-engine:

```
@echo off
set JAVA_HOME="C:\Users\josh\.jdks\corretto-21.0.3"
set temp_wrims2=".\foo"
set PATH=%PATH%;wrims-comparison-test\build\lib;projects\danube\Run\External

%JAVA_HOME%\bin\java -Xmx2048m -Xss1024K -cp "wrims-core\build\libs\*;wrims-core\build\tmp\libs\*" wrimsv2.components.ControllerBatch -launch=projects\danube\CS3_Adjusted_Dev.launch
pause
```

# Screenshots (if appropriate):

# Types of changes