### PR TITLE
Issue #78 - Force build failure when wrims-engine-dependencies 

### DIFF
--- a/.github/workflows/Java_CI.yaml
+++ b/.github/workflows/Java_CI.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Verify token access to wrims-engine-dependencies
         shell: bash
         run: |
-          curl -i -u "dwr-wrims-build:${{ secrets.WRIMS_ENGINE_DEPENDENCIES_TOKEN }}" \
+          curl --fail -i -u "dwr-wrims-build:${{ secrets.WRIMS_ENGINE_DEPENDENCIES_TOKEN }}" \
             https://maven.pkg.github.com/CentralValleyModeling/wrims-engine-dependencies/com.google.ortools/linearsolver/2013-01-10/linearsolver-2013-01-10.jar
 
       - name: Set up JDK 21


### PR DESCRIPTION
# Description

This PR adjusted the curl call to make the build fail immediately when the build is unable to access the wrims-engine-dependencies. 

# Motivation and Context

It is expected for wrims-engine build to fail when the Person Access Token for the wrims-build-user expires or is revoked for some reason. Previously, the check would fail quietly and it would take another minute of compute time before it would fail on an expected compute access making it take extra steps to investigate and wasting some compute time. 

# How Has This Been Tested?

A test build was run with a known bad inputs for the curl user/token to verify the step would fail out of the workflow when the curl test failed. 

# Screenshots (if appropriate):

# Types of changes

Workflow yaml change