### PR TITLE
#80: Moved code checkout to be first step in Sonar action

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -13,6 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run && github.event.workflow_run.conclusion == 'success'
     steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4.2.2
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth:
+            0
       - name: Set up JDK 21
         uses: actions/setup-java@v4.7.1
         with:
@@ -21,12 +28,6 @@ jobs:
           cache: 'gradle'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4.3.1
-      - name: Checkout PR
-        uses: actions/checkout@v4.2.2
-        with:
-          repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.workflow_run.head_branch }}
-          fetch-depth: 0
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
Fixes #80 

Due to issue with action run seen [here](https://github.com/CentralValleyModeling/wrims-engine/actions/runs/17479078361/job/49645697749), moved code checkout to be first step in Sonar action.