### PR TITLE
CI/CD: Added check for tagged release to package publish task

### DIFF
--- a/.github/workflows/Java_CI.yaml
+++ b/.github/workflows/Java_CI.yaml
@@ -57,6 +57,7 @@ jobs:
             ./*/build/reports/**
 
       - name: Publish package
+        if: startsWith(github.ref, 'refs/tags/')
         run: ./gradlew publish -PcvmUserId="dwr-wrims-build" -PcvmPassword="${{ secrets.WRIMS_ENGINE_DEPENDENCIES_TOKEN }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add check for tag when publishing to package repository. Prevents publishing when building for Dependabot or standard pull requests.