### PR TITLE
Return to cycle1 for infeasibility

### DIFF
--- a/run_wrims_study_example.bat
+++ b/run_wrims_study_example.bat
@@ -1,10 +1,10 @@
 @echo off
 REM PROJECT SETTINGS: PROJECT_DIR, and CONFIG_FILE variables as needed.
-set "PROJECT_DIR=C:\Users\hzamanis\Documents\Projects\calsim3-dcr-main_base"
-set CONFIG_FILE=__study.config
+set PROJECT_DIR=J:\wrims\projects\dcr2023
+set CONFIG_FILE=study.config
 
 REM Set the JAVA_HOME environment variable to the path of your java 21 JDK
-set JAVA_HOME="C:\Program Files\Java\jdk-21"
+set JAVA_HOME="J:\java\jdk\jdk_21.0.8_temurin"
 
 set temp_wrims2=".\foo"
 

--- a/wrims-core/src/main/java/wrimsv2/components/ControllerBatch.java
+++ b/wrims-core/src/main/java/wrimsv2/components/ControllerBatch.java
@@ -369,7 +369,7 @@ public class ControllerBatch {
 						
 						if (ControlData.showRunTimeMessage) System.out.println("Solving Done.");
 						
-						int cycleI=i+1;
+
 						if (Error.error_solving.size()<1){
 							ControlData.isPostProcessing=true;
 							mds.processAlias();
@@ -391,6 +391,7 @@ public class ControllerBatch {
                             ILP.logging=true;
                             ILP.loggingVariableValue=true;
 						}
+                        int cycleI=i+1;
 						String strCycleI=cycleI+"";
 						boolean isSelectedCycleOutput=General.isSelectedCycleOutput(strCycleI);
 						if (ControlData.outputType==1){
@@ -1009,7 +1010,7 @@ public class ControllerBatch {
 						
 						if (ControlData.showRunTimeMessage) System.out.println("Solving Done.");
 						
-						int cycleI=i+1;
+
 						if (Error.error_solving.size()<1){
 							ControlData.isPostProcessing=true;
 							mds.processAlias();
@@ -1031,6 +1032,7 @@ public class ControllerBatch {
                             ILP.logging=true;
                             ILP.loggingVariableValue=true;
 						}
+                        int cycleI=i+1;
 						String strCycleI=cycleI+"";
 						boolean isSelectedCycleOutput=General.isSelectedCycleOutput(strCycleI);
 						if (ControlData.outputType==1){
@@ -1293,7 +1295,7 @@ public class ControllerBatch {
 						
 						if (ControlData.showRunTimeMessage) System.out.println("Solving Done.");
 						
-						int cycleI=i+1;
+
 						if (Error.error_solving.size()<1){
 							ControlData.isPostProcessing=true;
 							mds.processAlias();
@@ -1315,6 +1317,7 @@ public class ControllerBatch {
                             ILP.logging=true;
                             ILP.loggingVariableValue=true;
 						}
+                        int cycleI=i+1;
 						String strCycleI=cycleI+"";
 						boolean isSelectedCycleOutput=General.isSelectedCycleOutput(strCycleI);
 						if (ControlData.outputType==1){
@@ -1456,7 +1459,7 @@ public class ControllerBatch {
 						
 						if (ControlData.showRunTimeMessage) System.out.println("Solving Done.");
 						
-						int cycleI=i+1;
+
 						if (Error.error_solving.size()<1){
 							ControlData.isPostProcessing=true;
 							mds.processAlias();
@@ -1478,6 +1481,7 @@ public class ControllerBatch {
                             ILP.logging=true;
                             ILP.loggingVariableValue=true;
 						}
+                        int cycleI=i+1;
 						String strCycleI=cycleI+"";
 						boolean isSelectedCycleOutput=General.isSelectedCycleOutput(strCycleI);
 						if (ControlData.outputType==1){
@@ -1692,7 +1696,7 @@ public class ControllerBatch {
 						
 						if (ControlData.showRunTimeMessage) System.out.println("Solving Done.");
 						
-						int cycleI=i+1;
+
 						if (Error.error_solving.size()<1){
 							ControlData.isPostProcessing=true;
 							mds.processAlias();
@@ -1714,6 +1718,7 @@ public class ControllerBatch {
                             ILP.logging=true;
                             ILP.loggingVariableValue=true;
 						}
+                        int cycleI=i+1;
 						String strCycleI=cycleI+"";
 						boolean isSelectedCycleOutput=General.isSelectedCycleOutput(strCycleI);
 						if (ControlData.outputType==1){


### PR DESCRIPTION
Revised infeasibility handling to enable logging from Cycle 1 of the infeasibility timestep

- Enabled log files starting at Cycle 1 when infeasibility occurs
- Updated logic to ensure DV file output is written before aborting the run
- Verified that all variables are saved up to the first cycle of the infeasibility step
- Added logic to save the LP model at the infeasibility timestep for debugging
<img width="2022" height="1090" alt="image" src="https://github.com/user-attachments/assets/34e99ac1-4772-4a01-80a0-38e9450110bc" />
<img width="1858" height="586" alt="image" src="https://github.com/user-attachments/assets/78c7274f-d328-4a3f-a975-4aafda3aa139" />

