### PR TITLE
Ignore `*.java.bak`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 tmp
 **/\.~lock*
 
+*.java.bak
 **/.gradle
 **/gradle/license-plugin/
 build/


### PR DESCRIPTION
Occasionally created files when using gradle, DSS, and other external tools. Ignoring them reduces the number of files added to the repo.