### PR TITLE
Bugfix: re-use a common fork pool for pre-processing

### DIFF
--- a/wrims-core/src/main/java/gov/ca/water/wrims/engine/core/commondata/wresldata/ModelDataSet.java
+++ b/wrims-core/src/main/java/gov/ca/water/wrims/engine/core/commondata/wresldata/ModelDataSet.java
@@ -34,14 +34,14 @@ import gov.ca.water.wrims.engine.core.components.Error;
 
 
 public class ModelDataSet implements Serializable {
-	
+    private static final ForkJoinPool pool = new ForkJoinPool();
 	private static final long serialVersionUID = 1L;
 	// / weight table   // <objName,  <itemName, value>>
-	public ArrayList<String> wtList = new ArrayList<String>();
-	public ArrayList<String> wtTimeArrayList = new ArrayList<String>();
-	public ArrayList<String> wtSlackSurplusList = new ArrayList<String>();
-	public CopyOnWriteArrayList<String> usedWtSlackSurplusList = new CopyOnWriteArrayList<String>();
-	public CopyOnWriteArrayList<String> usedWtSlackSurplusDvList = new CopyOnWriteArrayList<String>();
+	public ArrayList<String> wtList = new ArrayList<>();
+	public ArrayList<String> wtTimeArrayList = new ArrayList<>();
+	public ArrayList<String> wtSlackSurplusList = new ArrayList<>();
+	public CopyOnWriteArrayList<String> usedWtSlackSurplusList = new CopyOnWriteArrayList<>();
+	public CopyOnWriteArrayList<String> usedWtSlackSurplusDvList = new CopyOnWriteArrayList<>();
 
 //	public ArrayList<String> wtList_global = new ArrayList<String>();
 //	public ArrayList<String> wtList_local = new ArrayList<String>();
@@ -49,10 +49,10 @@ public class ModelDataSet implements Serializable {
 	public Map<String, WeightElement> wtSlackSurplusMap = new HashMap<String, WeightElement>();	
 
 	// / external function structure
-	public ArrayList<String> exList = new ArrayList<String>();
-	public ArrayList<String> exList_global = new ArrayList<String>();
-	public ArrayList<String> exList_local = new ArrayList<String>();
-	public Map<String, External> exMap = new HashMap<String, External>();
+	public ArrayList<String> exList = new ArrayList<>();
+	public ArrayList<String> exList_global = new ArrayList<>();
+	public ArrayList<String> exList_local = new ArrayList<>();
+	public Map<String, External> exMap = new HashMap<>();
 	
 	
 //    //  / sv, ts, and dv list
@@ -62,15 +62,15 @@ public class ModelDataSet implements Serializable {
 //	public ArrayList<String> svTsList = new ArrayList<String>();
 	
 	// / svar timeseries data structure
-	public ArrayList<String> tsList = new ArrayList<String>();
-	public ArrayList<String> tsList_global = new ArrayList<String>();
-	public ArrayList<String> tsList_local = new ArrayList<String>();
-	public Map<String, Timeseries> tsMap = new HashMap<String, Timeseries>();
+	public ArrayList<String> tsList = new ArrayList<>();
+	public ArrayList<String> tsList_global = new ArrayList<>();
+	public ArrayList<String> tsList_local = new ArrayList<>();
+	public Map<String, Timeseries> tsMap = new HashMap<>();
 	
 	// / svar data structure
-	public Set<String> svSet_unknown = new HashSet<String>();
-	public ArrayList<String> svList = new ArrayList<String>();
-	public ArrayList<String> svList_global = new ArrayList<String>();
+	public Set<String> svSet_unknown = new HashSet<>();
+	public ArrayList<String> svList = new ArrayList<>();
+	public ArrayList<String> svList_global = new ArrayList<>();
 	public ArrayList<String> svList_local = new ArrayList<String>();
 	public Map<String, Svar> svMap = new HashMap<String, Svar>();
 	public Map<String, Svar> svFutMap = new HashMap<String, Svar>();
@@ -155,7 +155,6 @@ public class ModelDataSet implements Serializable {
 		ControlData.currEvalTypeIndex=7;
 		wtTimeArrayList = new ArrayList<String>();
 		ProcessWeight pw = new ProcessWeight(wtList, wtMap, solverWtMap, wtTimeArrayList, 0, wtList.size()-1);
-		ForkJoinPool pool = new ForkJoinPool();
 		pool.invoke(pw);
 	}
 	
@@ -167,7 +166,6 @@ public class ModelDataSet implements Serializable {
 		ConcurrentHashMap<String, WeightElement> solverWeightSlackSurplusMap=SolverData.getWeightSlackSurplusMap();
 		ControlData.currEvalTypeIndex=7;
 		ProcessWeightSurplusSlack pwss = new ProcessWeightSurplusSlack(usedWtSlackSurplusDvList, wtSlackSurplusMap, solverWeightSlackSurplusMap, 0, usedWtSlackSurplusDvList.size()-1);
-		ForkJoinPool pool = new ForkJoinPool();
 		pool.invoke(pwss);
 	}
 	
@@ -339,7 +337,6 @@ public class ModelDataSet implements Serializable {
 		Map<String, Timeseries> tsMap =mds.tsMap;
 		ControlData.currEvalTypeIndex=5;
 		ProcessTimeseries pt = new ProcessTimeseries(tsList, tsMap, 0, tsList.size()-1);
-		ForkJoinPool pool = new ForkJoinPool();
 		pool.invoke(pt);
 	}
 	
@@ -358,7 +355,6 @@ public class ModelDataSet implements Serializable {
 		ArrayList<String> varCycleIndexList = sds.getVarCycleIndexList();
 		ArrayList<String> dvarTimeArrayCycleIndexList = sds.getDvarTimeArrayCycleIndexList();
 		ProcessDvar pd = new ProcessDvar(dvList, dvMap, solverDvarMap, timeArrayDvList, dvTimeArrayList, dvarUsedByLaterCycle, dvarTimeArrayUsedByLaterCycle, varCycleIndexList, dvarTimeArrayCycleIndexList, 0, dvList.size()-1);
-		ForkJoinPool pool = new ForkJoinPool();
 		pool.invoke(pd);
 	}
 	
@@ -371,7 +367,6 @@ public class ModelDataSet implements Serializable {
 		ConcurrentHashMap<String, EvalConstraint> solverGMap=SolverData.getConstraintDataMap();
 		gTimeArrayList = new ArrayList<String>();
 		ProcessConstraint pc = new ProcessConstraint(gList, gMap, solverGMap, gTimeArrayList, usedWtSlackSurplusList, usedWtSlackSurplusDvList, 0, gList.size()-1);
-		ForkJoinPool pool = new ForkJoinPool();
 		pool.invoke(pc);
 	}
 	


### PR DESCRIPTION
The prior implementation would create pools for each task, increasing the overhead for coordinating work. Updated implementation shares a single pool across all workers.

Testing showed that the previous implementation created hundreds of pools, each with a single worker. Updated implementation uses a single pool, with a maximum of two workers used.

## Comparison

Using CalLite to do the comparison, we see that the changes reduce the number of threads used at runtime, and the threads are more active overall. The total reported runtime is not impacted, and the reported time taken for processing is about the same as well. The memory footprint for the updated run remains stable during the entire run, where the prior implementation would slowly consume more memory over the course of a run.

## Old Implementation Threads

As seen using VisualVM. **Note the total count of ForkJoinPool threads at over 2,000.**

<img width="1570" height="958" alt="image" src="https://github.com/user-attachments/assets/1ccb9674-21f5-4a7e-98aa-7a9b323cb9f7" />


## New Implementation Threads

As seen using VisualVM.

<img width="1095" height="838" alt="image" src="https://github.com/user-attachments/assets/f2a3b080-77d1-4ef0-bf3d-10d17b34e9d6" />


## Timing Comparison 

| Task | Reported Time `main` | Reported Time `bugfix` |
| ---  | --- | --- | 
| Reported Total Runtime | 3 min, 17 sec | 3 min, 11 sec |
| Process Timeseries | 21 sec | 3 sec |
| Process Svar | 1 min, 7 sec | 1 min, 8 sec | 
| Process Dvar | 3 sec | 3 sec |
| Process Constraint | 7 sec | 7 sec |
| Process Weight | 1 sec | 1 sec |
| Process Weight Surplus/Slack | 0 sec | 0 sec |
| Process Alias | 3 sec | 3 sec |
