### PR TITLE
Configure logging during tests

### DIFF
--- a/wrims-comparison-test/src/test/resources/log4j2.xml
+++ b/wrims-comparison-test/src/test/resources/log4j2.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" monitorInterval="30">
+    <Properties>
+        <Property name="TEST_PATTERN">%d{ISO8601} %-5level [%t] [%c{1}] - %msg%n</Property>
+        <Property name="WRIMS_LOG_DIR">${sys:user.home}/.wrims/logs</Property>
+    </Properties>
+
+    <Appenders>
+        <!-- Console Appender -->
+        <Console name="CONSOLE" target="SYSTEM_OUT" follow="true">
+            <PatternLayout pattern="${USER_PATTERN}"/>
+        </Console>
+        <!-- Async wrapper for console -->
+        <Async name="CONSOLE-ASYNC">
+            <AppenderRef ref="CONSOLE"/>
+        </Async>
+
+        <!-- File Appender - Project Directory -->
+        <RollingFile
+                name="FILE"
+                fileName="${WRIMS_LOG_DIR}/tests/smoke-tests.log"
+                filePattern="${WRIMS_LOG_DIR}/tests/smoke-tests-%i.log"
+                append="true">
+            <PatternLayout pattern="${TEST_PATTERN}"/>
+            <Policies>
+                <OnStartupTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="50 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="100"/>
+        </RollingFile>
+        <!-- Async wrapper for file -->
+        <Async name="FILE-ASYNC">
+            <AppenderRef ref="FILE"/>
+        </Async>
+    </Appenders>
+
+    <Loggers>
+        <Root level="DEBUG">
+            <AppenderRef ref="CONSOLE-ASYNC" />
+            <AppenderRef ref="FILE-ASYNC" />
+        </Root>
+    </Loggers>
+
+</Configuration>

--- a/wrims-comparison-test/src/test/resources/log4j2.xml
+++ b/wrims-comparison-test/src/test/resources/log4j2.xml
@@ -8,7 +8,7 @@
     <Appenders>
         <!-- Console Appender -->
         <Console name="CONSOLE" target="SYSTEM_OUT" follow="true">
-            <PatternLayout pattern="${USER_PATTERN}"/>
+            <PatternLayout pattern="${TEST_PATTERN}"/>
         </Console>
         <!-- Async wrapper for console -->
         <Async name="CONSOLE-ASYNC">

--- a/wrims-core/src/test/java/gov/ca/water/wrims/engine/core/config/ConfigUtilsTest.java
+++ b/wrims-core/src/test/java/gov/ca/water/wrims/engine/core/config/ConfigUtilsTest.java
@@ -5,7 +5,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.appender.FileAppender;
+import org.apache.logging.log4j.core.appender.RollingFileAppender;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.config.Property;
@@ -84,7 +84,7 @@ final class ConfigUtilsTest {
 
         LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
         Configuration config = ctx.getConfiguration();
-        FileAppender fileAppender = config.getAppender("FILE");
+        RollingFileAppender fileAppender = config.getAppender("FILE");
         assertNotNull(fileAppender);
 
         File logFile = new File(fileAppender.getFileName());

--- a/wrims-core/src/test/resources/log4j2.xml
+++ b/wrims-core/src/test/resources/log4j2.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" monitorInterval="30">
+    <Properties>
+        <Property name="TEST_PATTERN">%d{ISO8601} %-5level [%t] [%c{1}] - %msg%n</Property>
+        <Property name="WRIMS_LOG_DIR">${sys:user.home}/.wrims/logs</Property>
+    </Properties>
+
+    <Appenders>
+        <!-- Console Appender -->
+        <Console name="CONSOLE" target="SYSTEM_OUT" follow="true">
+            <PatternLayout pattern="${USER_PATTERN}"/>
+        </Console>
+        <!-- Async wrapper for console -->
+        <Async name="CONSOLE-ASYNC">
+            <AppenderRef ref="CONSOLE"/>
+        </Async>
+
+        <!-- File Appender - Project Directory -->
+        <RollingFile
+                name="FILE"
+                fileName="${WRIMS_LOG_DIR}/tests/tests.log"
+                filePattern="${WRIMS_LOG_DIR}/tests/tests-%i.log"
+                append="true">
+            <PatternLayout pattern="${TEST_PATTERN}"/>
+            <Policies>
+                <OnStartupTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="50 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="100"/>
+        </RollingFile>
+        <!-- Async wrapper for file -->
+        <Async name="FILE-ASYNC">
+            <AppenderRef ref="FILE"/>
+        </Async>
+    </Appenders>
+
+    <Loggers>
+        <Root level="DEBUG">
+            <AppenderRef ref="CONSOLE-ASYNC" />
+            <AppenderRef ref="FILE-ASYNC" />
+        </Root>
+    </Loggers>
+
+</Configuration>

--- a/wrims-core/src/test/resources/log4j2.xml
+++ b/wrims-core/src/test/resources/log4j2.xml
@@ -8,7 +8,7 @@
     <Appenders>
         <!-- Console Appender -->
         <Console name="CONSOLE" target="SYSTEM_OUT" follow="true">
-            <PatternLayout pattern="${USER_PATTERN}"/>
+            <PatternLayout pattern="${TEST_PATTERN}"/>
         </Console>
         <!-- Async wrapper for console -->
         <Async name="CONSOLE-ASYNC">


### PR DESCRIPTION
## Objective

Align the logging that occurs during tests with the logging framework used by the rest of WRIMS Engine. Add log4j configuration files:

- [`wrims-engine/src/test/resources/log4j2.xml`](./wrims-engine/src/test/resources/log4j2.xml)
- [`wrims-comparison-test/src/test/resources/log4j2.xml`](wrims-comparison-test/src/test/resources/log4j2.xml)