### PR TITLE
Devops/test performance timer

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -78,7 +78,9 @@ slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j"}
 slf4j-log4j-bindings = { module = "org.apache.logging.log4j:log4j-slf4j2-impl", version.ref = "log4j"}
 log4j = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j"}
 log4j-async = {module = "com.lmax:disruptor", version.ref = "lmax"}
+log4j-test = { module = "org.apache.logging.log4j:log4j-core-test", version.ref = "log4j"}
 
 [bundles]
 junit5 = [ "junit-5-engine", "junit-5-api", "junit-5-params", "junit-jupiter", "junit-platform-suite" ]
 cucumber = [ "cucumber-java", "cucumber-junit" ]
+log4j = ["log4j", "log4j-async" ,"log4j-test"]

--- a/wrims-core/build.gradle
+++ b/wrims-core/build.gradle
@@ -70,9 +70,7 @@ dependencies {
     // Logging
     implementation libs.slf4j
     implementation libs.slf4j.log4j.bindings
-    implementation libs.log4j
-    runtimeOnly libs.log4j.async
-
+    implementation libs.bundles.log4j
 }
 
 // This moves .tokens files into the same generated-src files with the .java files

--- a/wrims-core/src/test/java/gov/ca/water/wrims/engine/core/solver/TestPerformanceTimer.java
+++ b/wrims-core/src/test/java/gov/ca/water/wrims/engine/core/solver/TestPerformanceTimer.java
@@ -1,0 +1,101 @@
+package gov.ca.water.wrims.engine.core.solver;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestPerformanceTimer {
+    private static ListAppender appender = null;
+
+    @BeforeAll
+    static void setupAll() {
+        Logger logger = (Logger) LogManager.getLogger(PerformanceTimer.class);
+        appender = new ListAppender(TestPerformanceTimer.class.getName());
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @AfterAll
+    static void teardownAll() {
+        Logger logger = (Logger) LogManager.getLogger(PerformanceTimer.class);
+        logger.removeAppender(appender);
+    }
+
+    @Test
+    void testUniqueString() {
+        String sameString = "foo";
+        PerformanceTimer timerA = new PerformanceTimer(sameString);
+        PerformanceTimer timerB = new PerformanceTimer(sameString);
+        assertNotSame(timerA.toString(), timerB.toString(), "timers with the same operation should still be unique");
+    }
+
+    @Test
+    void testLogOnStop() {
+        String operation = "testLogOnStop";
+        PerformanceTimer timer = new PerformanceTimer(operation);
+        timer.stop();
+
+        List<LogEvent> found = appender.getEvents()
+                                       .stream()
+                                       .filter(e -> e.getMessage().getFormattedMessage().contains(operation))
+                                       .filter(e -> e.getMessage().getFormattedMessage().contains("event=\"stop\""))
+                                       .toList();
+
+        assertEquals(1, found.size(), "there should only be 1 stop event logged");
+    }
+
+    @Test
+    void testLogStart() {
+        String operation = "testReportError";
+        new PerformanceTimer(operation);
+
+        boolean found = appender.getEvents()
+                                .stream()
+                                .filter(e -> e.getMessage().getFormattedMessage().contains(operation))
+                                .anyMatch(e -> e.getMessage().getFormattedMessage().contains("event=\"start\""));
+
+        assertTrue(found, "timer should emit a start event on object creation");
+    }
+
+    @Test
+    void testReportError() {
+        String operation = "testReportError";
+        PerformanceTimer timer = new PerformanceTimer(operation);
+        timer.report("error");
+
+        boolean found = appender.getEvents()
+                                .stream()
+                                .filter(e -> e.getMessage().getFormattedMessage().contains(operation))
+                                .filter(e -> e.getMessage().getFormattedMessage().contains("event=\"error\""))
+                                .allMatch(e -> e.getLevel() == Level.ERROR);
+
+        assertTrue(found, "all `event=\"error\"` should log at the ERROR level");
+    }
+
+    @Test
+    void testRepeatReport() {
+        String operation = "testRepeatReport";
+        PerformanceTimer timer = new PerformanceTimer(operation);
+        int numReports = 10;
+        for (int i = 0; i < numReports; i++) {
+            timer.report();
+        }
+        List<LogEvent> found = appender.getEvents()
+                                       .stream()
+                                       .filter(e -> e.getMessage().getFormattedMessage().contains(operation))
+                                       .filter(e -> e.getMessage().getFormattedMessage().contains("event=\"report\""))
+                                       .toList();
+        assertEquals(numReports, found.size(), "there should be " + numReports + " reports logged");
+    }
+}


### PR DESCRIPTION
Add tests for the custom timer class. 

Tests are minimal as the long term plan is to remove these custom timer classes in favor of a more standard metrics solution.