### PR TITLE
Test for failure modes on `BuildProps`

### DIFF
--- a/wrims-core/src/main/java/gov/ca/water/wrims/engine/core/components/BuildProps.java
+++ b/wrims-core/src/main/java/gov/ca/water/wrims/engine/core/components/BuildProps.java
@@ -8,21 +8,45 @@ import java.util.Properties;
 
 public class BuildProps {
     private final Properties properties;
+    public static final String DEFAULT_FILE = "wrims-engine-build.properties";
+    public static final String UNKNOWN_VERSION_TAG = "3+unknown";
     private static final Logger LOGGER = LoggerFactory.getLogger(BuildProps.class);
 
+    /**
+     * Create a `BuildProps` object with the default file for WRIMS.
+     */
     public BuildProps() {
+        this(DEFAULT_FILE);
+    }
+
+    /**
+     * Create a `BuildProps` object given a specific properties file.
+     * @param propertiesFile the String path to the properties file.
+     */
+    public BuildProps(String propertiesFile) {
         properties = new Properties();
-        String defaultFile = "wrims-engine-build.properties";
-        InputStream stream = this.getClass().getClassLoader().getResourceAsStream(defaultFile);
         try {
+            InputStream stream = this.getClass().getClassLoader().getResourceAsStream(propertiesFile);
+            properties.clear();
             properties.load(stream);
         } catch (NullPointerException | IOException e) {
-            LOGGER.atError().setMessage(System.getProperty("java.class.path")).log();
-            LOGGER.atError().setMessage("could not find default properties file: {}").addArgument(defaultFile).log();
+            LOGGER.atError()
+                  .setMessage("IOException for properties file: {}")
+                  .addArgument(propertiesFile)
+                  .setCause(e)
+                  .log();
         }
     }
 
+    /**
+     * Get the Version Number, saved with the key `version` in properties.
+     * @return value of `version` in the properties.
+     */
     public String getVN() {
-        return properties.getProperty("version");
+        String vn = properties.getProperty("version");
+        if (vn == null) {
+            vn = UNKNOWN_VERSION_TAG;
+        }
+        return vn;
     }
 }

--- a/wrims-core/src/test/java/gov/ca/water/wrims/engine/core/components/BuildPropsTest.java
+++ b/wrims-core/src/test/java/gov/ca/water/wrims/engine/core/components/BuildPropsTest.java
@@ -9,4 +9,14 @@ class BuildPropsTest {
         BuildProps buildProps = new BuildProps();
         Assert.assertNotNull(buildProps.getVN(), "the version number should not be null");
     }
+
+    @Test
+    void testUnknownWhenNotFound() {
+        BuildProps buildProps = new BuildProps("not-a-real-file.properties");
+        Assert.assertEquals(
+                buildProps.getVN(),
+                BuildProps.UNKNOWN_VERSION_TAG,
+                "the version number should default to an unknown"
+        );
+    }
 }


### PR DESCRIPTION
Refactors `BuildProps` for easier test harnessing, and adds a test for the failure to read the build.properties file.