### PR TITLE
Correctly classify ANTLR grammar files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Correctly classify our grammar files as "ANTLR", and not "GAP" files.
+*.g linguist-language=ANTLR


### PR DESCRIPTION
## Description

Adds a `.gitattributes` file to [configure](https://github.com/github-linguist/linguist/blob/main/docs/overrides.md#using-gitattributes) the GitHub [linguist](https://github.com/github-linguist/linguist) tool that indexes the files in this repo. Manually classify the ANTLR 3 grammar (`*.g`) files as [ANTLR](https://github.com/github-linguist/linguist/blob/ba889d055394142b74643b126af23ba62b716d2b/lib/linguist/languages.yml#L136) and not as [GAP](https://github.com/github-linguist/linguist/blob/ba889d055394142b74643b126af23ba62b716d2b/lib/linguist/languages.yml#L2371) files.

No code changes.