### PR TITLE
Move headless instructions to read the docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,52 +33,9 @@ Prior to the present revison of the WRIMS build system, the equivalent of WRIMS-
    git clone https://github.com/CentralValleyModeling/wrims-engine.git
    ```
    
-# RUNNING HEADLESS WRIMS ENGINE COMPUTE
-The WRIMS engine can be run headless (without the GUI) using the `wrims-core` jar along with all dependency jars and libs. 
-This is useful for running batch processes or automated tests.
+# Running Headless WRIMS Engine Compute
+See the [docs page](.\docs\headless.rst) for help running WRIMS Engine without the GUI.
 
-Here are the required steps to run a headless compute with the WRIMS engine jar directly:
-
-1. Build the wrims-core module. This will create a jar file in the `wrims-core/build/libs` directory and the copy the dependent jars into `wrims-core/build/tmp/libs`.
-   ```sh
-   ./gradlew :wrims-core:build
-   ```
-2. Run the "getNatives" task in the wrims-core module. This will download all the required dll files into the `wrims-core/build/tmp/x64` directory. 
-   ```sh
-    ./gradlew :wrims-core:getNatives
-   ```
-3. Clone the run_wrims_study_example.bat file in the root directory of the wrims-engine folder and update the project directory and config file paths.
-   ```bat
-   @echo off
-   REM PROJECT SETTINGS: PROJECT_DIR, and CONFIG_FILE variables as needed.
-   set PROJECT_DIR=J:\wrims\projects\dcr2023
-   set CONFIG_FILE=study.config
-   
-   REM Set the JAVA_HOME environment variable to the path of your java 21 JDK
-   set JAVA_HOME="J:\java\jdk\jdk_21.0.8_temurin"
-   
-   set temp_wrims2=".\foo"
-   
-   REM Add the required DLLs to the PATH. Do not change if this if run from the wrims-engine root directory.
-   set PATH=%PATH%;wrims-core\build\tmp\x64
-   
-   REM Add the external libraries to the PATH. Do not change.
-   set PATH=%PATH%;%PROJECT_DIR%\Run\External
-   
-   REM Set the main class to run. This is the entry point for the WRIMS application. Do not change when running from wrims-engine root.
-   set MAIN_CLASS=gov.ca.water.wrims.engine.core.components.ControllerBatch
-   set WRIMS_CORE_JAR="wrims-core\build\libs\*"
-   set WRIMS_CORE_DEPENDENCIES="wrims-core\build\tmp\libs\*"
-   
-   %JAVA_HOME%\bin\java -Xmx4096m -Xss1024K -cp "%WRIMS_CORE_JAR%;%WRIMS_CORE_DEPENDENCIES%" %MAIN_CLASS% -config=%PROJECT_DIR%\%CONFIG_FILE%
-   pause
-   ```   
-
-4. Run the batch file from a terminal or double-click it to execute the bat file.
-   ```sh
-   run_project.bat
-   ```
-   
 # Dependabot Configuration
 This repository uses Dependabot to keep dependencies up to date. The configuration file is located at `.github/dependabot.yml`. 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "myst_parser",
+    "sphinx_design",
 ]
 
 intersphinx_mapping = {

--- a/docs/headless.rst
+++ b/docs/headless.rst
@@ -1,3 +1,5 @@
+.. _headless:
+
 Running the WRIMS Engine in Headless Mode
 ==========================================
 

--- a/docs/headless.rst
+++ b/docs/headless.rst
@@ -28,6 +28,8 @@ Prerequisites
 Steps
 -----
 
+.. _headless_step_1:
+
 1. Build the ``wrims-core`` Module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -49,16 +51,15 @@ project root directory.
 The Gradle ``build`` task compiles the ``wrims-eninge`` JAR file and produces
 two directories:
 
-.. list-table::
-   :widths: 25 75
-   :header-rows: 1
+- ``wrims-core/build/libs/``
 
-   * - ``wrims-core/build/libs/``
-     - Contains the ``wrims-core`` JAR file, which holds all of the classes
-       that run WRIMS models.
-   * - ``wrims-core/build/tmp/libs/``
-     - Contains all dependency JARs, like the JARs needed to write DSS files, or
-       use the MILP solvers.
+  - Contains the ``wrims-core`` JAR file, which holds all of the classes that run WRIMS models.
+
+- ``wrims-core/build/tmp/libs/``
+
+  - Contains all dependency JARs, like the JARs needed to use the MILP solvers.
+
+.. _headless_step_2:
 
 2. Download Native Libraries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -71,13 +72,14 @@ These are placed in ``wrims-core/build/tmp/x64/`` and must be on the system
 
    ./gradlew :wrims-core:getNatives
 
-.. info::
+.. note::
 
    Why does this not happen with the ``build`` task: these DLL files don't
    change very often, so it speeds up our build times to separate these steps.
    If you aren't planning on developing new versions of WRIMS Engine, you don't
    need to worry about the details here.
 
+.. _headless_step_3:
 
 3. Configure the Batch Script
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -97,10 +99,11 @@ then edit the two project-specific variables at the top:
    * - ``CONFIG_FILE``
      - Name of the study configuration file within that directory (e.g., ``study.config``)
 
-.. note::
+.. warning::
 
    You must also set the ``JAVA_HOME`` environment variable to point to your
-   Java 21 JDK installation.
+   Java 21 JDK installation. This is something that is set on your machine, not
+   in the batch file.
 
 The remaining variables control Java classpath and entry-point settings. **Do
 not change these unless you have moved the script out of the repository root.**
@@ -140,6 +143,8 @@ Below is the full annotated batch file for reference:
 
    pause
 
+.. _headless_step_4:
+
 4. Run the Batch File
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -157,24 +162,22 @@ any output or error messages before it closes.
 Troubleshooting
 ---------------
 
-.. list-table::
-   :widths: 35 65
-   :header-rows: 1
+.. dropdown:: ``java`` not found
 
-   * - Symptom
-     - What to check
-   * - ``java`` not found
-     - Verify that ``JAVA_HOME`` points to a valid Java 21 JDK directory and that
-       ``%JAVA_HOME%\bin\java.exe`` exists.
-   * - Missing DLL errors on startup
-     - Confirm that Step 2 completed successfully and that
-       ``wrims-core\build\tmp\x64`` is populated.
-   * - ``ClassNotFoundException`` for ``ControllerBatch``
-     - Confirm that Step 1 completed successfully and that
-       ``wrims-core\build\libs\`` and ``wrims-core\build\tmp\libs\`` are populated.
-   * - Study config not found
-     - Double-check that ``PROJECT_DIR`` and ``CONFIG_FILE`` together form the
-       correct absolute path to your ``study.config`` file.
-   * - Script must be run from the repository root
-     - The classpath and DLL path entries are relative. Always launch the script
-       from the ``wrims-engine`` root directory, not from a subdirectory.
+   Verify that ``JAVA_HOME`` points to a valid Java 21 JDK directory and that ``%JAVA_HOME%\bin\java.exe`` exists.
+
+.. dropdown:: Missing DLL errors on startup
+
+   Confirm that :ref:`Step 2<headless_step_2>` completed successfully and that ``wrims-core\build\tmp\x64`` is populated.
+
+.. dropdown:: ``ClassNotFoundException`` for ``ControllerBatch``
+
+   Confirm that :ref:`Step 1<headless_step_1>` completed successfully and that ``wrims-core\build\libs\`` and ``wrims-core\build\tmp\libs\`` are populated.
+
+.. dropdown:: Study config not found
+
+   Double-check that ``PROJECT_DIR`` and ``CONFIG_FILE`` together form the correct absolute path to your ``study.config`` file.
+
+.. dropdown:: Script must be run from the repository root
+
+   The classpath and DLL path entries are relative. Always launch the script from the ``wrims-engine`` root directory, not from a subdirectory.

--- a/docs/headless.rst
+++ b/docs/headless.rst
@@ -1,0 +1,146 @@
+Running the WRIMS Engine in Headless Mode
+==========================================
+
+Overview
+--------
+
+The WRIMS engine can be run **headless** (without the graphical interface) by invoking
+the ``wrims-core`` JAR directly alongside its dependency JARs and native libraries.
+This is useful for batch processing, automated testing, or running studies from a
+CI/CD pipeline or scheduled task.
+
+.. note::
+
+   These instructions assume you are working from the root directory of the
+   ``wrims-engine`` repository and that you have a Java 21 JDK installed.
+
+Prerequisites
+-------------
+
+- Java 21 JDK (e.g., `Eclipse Temurin <https://adoptium.net/>`_)
+- Gradle (the project includes a wrapper, so a local installation is not required)
+- A WRIMS project directory containing a ``study.config`` file
+
+Steps
+-----
+
+Step 1 — Build the ``wrims-core`` Module
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Run the Gradle build task for ``wrims-core``. This compiles the module and produces
+two directories:
+
+- ``wrims-core/build/libs/`` — contains the ``wrims-core`` JAR
+- ``wrims-core/build/tmp/libs/`` — contains all dependency JARs
+
+.. code-block:: sh
+
+   ./gradlew :wrims-core:build
+
+Step 2 — Download Native Libraries
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Run the ``getNatives`` task to download the required Windows DLL files. These are
+placed in ``wrims-core/build/tmp/x64/`` and must be on the system ``PATH`` at
+runtime.
+
+.. code-block:: sh
+
+   ./gradlew :wrims-core:getNatives
+
+Step 3 — Configure the Launch Script
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A template batch file, ``run_wrims_study_example.bat``, is provided in the root of
+the repository. Copy it and rename it for your project (e.g., ``run_project.bat``),
+then edit the two project-specific variables at the top:
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Variable
+     - Description
+   * - ``PROJECT_DIR``
+     - Absolute path to your WRIMS project directory (e.g., ``J:\wrims\projects\dcr2023``)
+   * - ``CONFIG_FILE``
+     - Name of the study configuration file within that directory (e.g., ``study.config``)
+
+You must also set ``JAVA_HOME`` to point to your Java 21 JDK installation.
+
+The remaining variables control classpath and entry-point settings. **Do not change
+these unless you have moved the script out of the repository root.**
+
+Below is the full annotated batch file for reference:
+
+.. code-block:: bat
+
+   @echo off
+
+   set PROJECT_DIR=J:\wrims\projects\dcr2023
+   set CONFIG_FILE=study.config
+
+   REM Path to your Java 21 JDK installation
+   set JAVA_HOME="J:\java\jdk\jdk_21.0.8_temurin"
+
+   set temp_wrims2=".\foo"
+
+   REM Add native DLLs to PATH (relative to wrims-engine root — do not change)
+   set PATH=%PATH%;wrims-core\build\tmp\x64
+
+   REM Add project-specific external libraries to PATH (do not change)
+   set PATH=%PATH%;%PROJECT_DIR%\Run\External
+
+   REM Entry point for headless execution (do not change)
+   set MAIN_CLASS=gov.ca.water.wrims.engine.core.components.ControllerBatch
+
+   REM Classpath entries (do not change when running from wrims-engine root)
+   set WRIMS_CORE_JAR="wrims-core\build\libs\*"
+   set WRIMS_CORE_DEPENDENCIES="wrims-core\build\tmp\libs\*"
+
+   REM Launch the engine with 4 GB heap and an extended thread stack size
+   %JAVA_HOME%\bin\java -Xmx4096m -Xss1024K ^
+       -cp "%WRIMS_CORE_JAR%;%WRIMS_CORE_DEPENDENCIES%" ^
+       %MAIN_CLASS% ^
+       -config=%PROJECT_DIR%\%CONFIG_FILE%
+
+   pause
+
+Step 4 — Run the Batch File
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Execute the batch file from the ``wrims-engine`` root directory. You can either
+double-click it in Windows Explorer or run it from a terminal:
+
+.. code-block:: bat
+
+   run_project.bat
+
+The engine will start, load the study configuration, and run to completion. The
+``pause`` at the end of the script keeps the terminal window open so you can review
+any output or error messages before it closes.
+
+Troubleshooting
+---------------
+
+.. list-table::
+   :widths: 35 65
+   :header-rows: 1
+
+   * - Symptom
+     - What to check
+   * - ``java`` not found
+     - Verify that ``JAVA_HOME`` points to a valid Java 21 JDK directory and that
+       ``%JAVA_HOME%\bin\java.exe`` exists.
+   * - Missing DLL errors on startup
+     - Confirm that Step 2 completed successfully and that
+       ``wrims-core\build\tmp\x64`` is populated.
+   * - ``ClassNotFoundException`` for ``ControllerBatch``
+     - Confirm that Step 1 completed successfully and that
+       ``wrims-core\build\libs\`` and ``wrims-core\build\tmp\libs\`` are populated.
+   * - Study config not found
+     - Double-check that ``PROJECT_DIR`` and ``CONFIG_FILE`` together form the
+       correct absolute path to your ``study.config`` file.
+   * - Script must be run from the repository root
+     - The classpath and DLL path entries are relative. Always launch the script
+       from the ``wrims-engine`` root directory, not from a subdirectory.

--- a/docs/headless.rst
+++ b/docs/headless.rst
@@ -19,39 +19,68 @@ CI/CD pipeline or scheduled task.
 Prerequisites
 -------------
 
-- Java 21 JDK (e.g., `Eclipse Temurin <https://adoptium.net/>`_)
-- Gradle (the project includes a wrapper, so a local installation is not required)
-- A WRIMS project directory containing a ``study.config`` file
+- Clone the ``wrims-engine`` repository.
+- Have Java 21 JDK available (e.g., `Eclipse Temurin <https://adoptium.net/>`_)
+- A WRIMS model directory containing a ``study.config`` file. (These
+  ``study.config`` files are similar to the ``.launch`` files that WRIMS GUI
+  uses. To create your own, refer to the :ref:`configuration` page.
 
 Steps
 -----
 
-Step 1 — Build the ``wrims-core`` Module
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1. Build the ``wrims-core`` Module
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Run the Gradle build task for ``wrims-core``. This compiles the module and produces
-two directories:
-
-- ``wrims-core/build/libs/`` — contains the ``wrims-core`` JAR
-- ``wrims-core/build/tmp/libs/`` — contains all dependency JARs
+Run the Gradle ``build`` task for ``wrims-core`` from the ``wrims-engine``
+project root directory.
 
 .. code-block:: sh
 
    ./gradlew :wrims-core:build
 
-Step 2 — Download Native Libraries
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. note::
 
-Run the ``getNatives`` task to download the required Windows DLL files. These are
-placed in ``wrims-core/build/tmp/x64/`` and must be on the system ``PATH`` at
-runtime.
+   Gradle is a muti-use tool for Java projects. Don't worry too much about
+   learning how to use it if all you want to do is run WRIMS. All you need to
+   know is that it is helpful in downloading all of the dependencies WRIMS
+   needs, and putting those in the appropriate location on your machine. If you
+   use Python, Gradle is similar to Conda.
+
+The Gradle ``build`` task compiles the ``wrims-eninge`` JAR file and produces
+two directories:
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - ``wrims-core/build/libs/``
+     - Contains the ``wrims-core`` JAR file, which holds all of the classes
+       that run WRIMS models.
+   * - ``wrims-core/build/tmp/libs/``
+     - Contains all dependency JARs, like the JARs needed to write DSS files, or
+       use the MILP solvers.
+
+2. Download Native Libraries
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Run the Gradle ``getNatives`` task to download the required Windows DLL files.
+These are placed in ``wrims-core/build/tmp/x64/`` and must be on the system
+``PATH`` at runtime.
 
 .. code-block:: sh
 
    ./gradlew :wrims-core:getNatives
 
-Step 3 — Configure the Launch Script
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. info::
+
+   Why does this not happen with the ``build`` task: these DLL files don't
+   change very often, so it speeds up our build times to separate these steps.
+   If you aren't planning on developing new versions of WRIMS Engine, you don't
+   need to worry about the details here.
+
+
+3. Configure the Batch Script
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A template batch file, ``run_wrims_study_example.bat``, is provided in the root of
 the repository. Copy it and rename it for your project (e.g., ``run_project.bat``),
@@ -68,10 +97,13 @@ then edit the two project-specific variables at the top:
    * - ``CONFIG_FILE``
      - Name of the study configuration file within that directory (e.g., ``study.config``)
 
-You must also set ``JAVA_HOME`` to point to your Java 21 JDK installation.
+.. note::
 
-The remaining variables control classpath and entry-point settings. **Do not change
-these unless you have moved the script out of the repository root.**
+   You must also set the ``JAVA_HOME`` environment variable to point to your
+   Java 21 JDK installation.
+
+The remaining variables control Java classpath and entry-point settings. **Do
+not change these unless you have moved the script out of the repository root.**
 
 Below is the full annotated batch file for reference:
 
@@ -108,8 +140,8 @@ Below is the full annotated batch file for reference:
 
    pause
 
-Step 4 — Run the Batch File
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+4. Run the Batch File
+~~~~~~~~~~~~~~~~~~~~~
 
 Execute the batch file from the ``wrims-engine`` root directory. You can either
 double-click it in Windows Explorer or run it from a terminal:

--- a/docs/home.rst
+++ b/docs/home.rst
@@ -16,10 +16,10 @@ If you are new to WRIMS, the recommended path is:
 
 1. Install WRIMS GUI. Starting out with WRIMS Engine is probably not the best
    entry point.
-2. Open an existing study in the GUI to familiarise yourself with the project
-   structure and configuration files.
+2. Check out the :ref:`WRIMS GUI Docs<wrims-gui:home>` to learn how to use
+   WRIMS from the graphical interface.
 3. When you are ready to run studies programmatically or in batch, refer to the
-   headless execution guide below.
+   headless guide here: :ref:`headless`.
 
 Contents
 --------

--- a/docs/home.rst
+++ b/docs/home.rst
@@ -4,5 +4,52 @@ WRIMS Engine
 ============
 
 .. note::
-    This documentation project is under active development.
 
+   This documentation is a work in progress. Pages are being added over time.
+   If you need guidance on a topic not yet covered here, please reach out to
+   your project team or consult the in-application help.
+
+Getting Started
+---------------
+
+If you are new to WRIMS, the recommended path is:
+
+1. Install WRIMS GUI. Starting out with WRIMS Engine is probably not the best
+   entry point.
+2. Open an existing study in the GUI to familiarise yourself with the project
+   structure and configuration files.
+3. When you are ready to run studies programmatically or in batch, refer to the
+   headless execution guide below.
+
+Contents
+--------
+
+.. toctree::
+   :maxdepth: 1
+   :caption: How-To Guides
+
+   running_headless_wrims_engine
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Reference
+
+   configuration
+
+.. note::
+
+   The **Configuration Reference** page is not yet written. The entry above is
+   a placeholder to show where it will appear in the navigation.
+
+About WRIMS
+-----------
+
+WRIMS is developed and maintained by the `California Department of Water
+Resources <https://water.ca.gov/>`_. It is primarily used for planning and
+operational studies of the State Water Project and the Central Valley water
+system, though its general modeling framework can be applied to other
+large-scale water resource networks.
+
+The engine solves a linear program at each cycle/timestep to determine optimal
+allocations and deliveries given the network topology, physical constraints,
+and operational priorities defined in the study configuration.

--- a/docs/home.rst
+++ b/docs/home.rst
@@ -24,31 +24,29 @@ If you are new to WRIMS, the recommended path is:
 Contents
 --------
 
-.. toctree::
-   :maxdepth: 1
-   :caption: How-To Guides
+How To
+^^^^^^
 
-   running_headless_wrims_engine
+- :ref:`headless`
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Reference
+Reference
+^^^^^^^^^
 
-   configuration
+- :ref:`Configuration File Structure <configuration>`
 
 .. note::
 
-   The **Configuration Reference** page is not yet written. The entry above is
-   a placeholder to show where it will appear in the navigation.
+   The **Configuration File Structure** page is not yet written. The entry above
+   is a placeholder to show where it will appear in the navigation.
 
 About WRIMS
 -----------
-
-WRIMS is developed and maintained by the `California Department of Water
-Resources <https://water.ca.gov/>`_. It is primarily used for planning and
+or planning and
 operational studies of the State Water Project and the Central Valley water
 system, though its general modeling framework can be applied to other
 large-scale water resource networks.
+WRIMS is developed and maintained by the `California Department of Water
+Resources <https://water.ca.gov/>`_. It is primarily used f
 
 The engine solves a linear program at each cycle/timestep to determine optimal
 allocations and deliveries given the network topology, physical constraints,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,3 +8,4 @@ Site Index
     :maxdepth: 2
 
     WRIMS Engine<home>
+    Headless Compute<headless>

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx==7.1.2
-sphinx-rtd-theme==1.3.0rc1
+sphinx-rtd-theme>=3.0.0
 myst-parser==3.0.1
+sphinx-design==0.7.0


### PR DESCRIPTION
Move the headless running information from the README to the Read the Docs pages.