### PR TITLE
Add configuration class for local cucumber tests

### DIFF
--- a/wrims-comparison-test/src/test/java/gov/ca/water/wrims/comparison/RunLocalCucumberTest.java
+++ b/wrims-comparison-test/src/test/java/gov/ca/water/wrims/comparison/RunLocalCucumberTest.java
@@ -1,0 +1,19 @@
+package gov.ca.water.wrims.comparison;
+
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("features/local")
+@ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "gov.ca.water.wrims.comparison.stepdefinitions")
+@ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty,summary")
+public class RunLocalCucumberTest {
+    // This class configures Cucumber to run all features in the local directory using the glue in stepdefinitions.
+    // No code is required here.
+}


### PR DESCRIPTION
## Description

Add a new cucumber configuration to run local models.

## Types of changes

Added `RunLocalCucumberTest.java` to the suite of `wrims-comparison-test` classes.

| Yes/No |  Pull Request Type          |  Description                                                          |
| ------ | --------------------------- | --------------------------------------------------------------------- |
|        | Bug fix                     | non-breaking change which fixes an issue                              |
|        | New feature                 | non-breaking change which adds functionality                          |
|        | Breaking change             | fix or feature that would cause existing functionality to change      | 
|        | Documentation change        | non-breaking change which modifies or updates documentation           |
|        | New tests                   | new unit tests, test scenarios, or test case documentation            | 
|        | Triggers regression testing | change affects downstream modules and will require regression testing | 
|     X  | Other                       |                                                                       | 

## How Has This Been Tested?

New class was used with local versions of DCR 2023.
